### PR TITLE
feat: add JWT auth system

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -6,9 +6,11 @@ require (
 	github.com/gin-contrib/cors v1.7.6
 	github.com/gin-contrib/zap v1.1.5
 	github.com/gin-gonic/gin v1.10.1
+	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/joho/godotenv v1.5.1
 	github.com/redis/go-redis/v9 v9.12.1
 	go.uber.org/zap v1.27.0
+	golang.org/x/crypto v0.41.0
 	gorm.io/driver/postgres v1.6.0
 	gorm.io/gorm v1.30.1
 )
@@ -44,7 +46,6 @@ require (
 	github.com/ugorji/go/codec v1.3.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/arch v0.18.0 // indirect
-	golang.org/x/crypto v0.41.0 // indirect
 	golang.org/x/net v0.43.0 // indirect
 	golang.org/x/sync v0.16.0 // indirect
 	golang.org/x/sys v0.35.0 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -37,6 +37,8 @@ github.com/go-playground/validator/v10 v10.26.0 h1:SP05Nqhjcvz81uJaRfEV0YBSSSGMc
 github.com/go-playground/validator/v10 v10.26.0/go.mod h1:I5QpIEbmr8On7W0TktmJAumgzX4CA1XNl4ZmDuVHKKo=
 github.com/goccy/go-json v0.10.5 h1:Fq85nIqj+gXn/S5ahsiTlK3TmC85qgirsdTP/+DeaC4=
 github.com/goccy/go-json v0.10.5/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
+github.com/golang-jwt/jwt/v5 v5.3.0 h1:pv4AsKCKKZuqlgs5sUmn4x8UlGa0kEVt/puTpKx9vvo=
+github.com/golang-jwt/jwt/v5 v5.3.0/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=

--- a/backend/internal/app/config.go
+++ b/backend/internal/app/config.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"os"
+	"time"
 
 	"github.com/joho/godotenv"
 )
@@ -18,21 +19,31 @@ type Config struct {
 	RedisPort string
 
 	APIPort string
+
+	JWTSecret       string
+	AccessTokenTTL  time.Duration
+	RefreshTokenTTL time.Duration
 }
 
 // LoadConfig reads configuration from the environment and optional .env file.
 func LoadConfig() (*Config, error) {
 	_ = godotenv.Load()
 
+	accessTTL, _ := time.ParseDuration(os.Getenv("JWT_ACCESS_TTL"))
+	refreshTTL, _ := time.ParseDuration(os.Getenv("JWT_REFRESH_TTL"))
+
 	cfg := &Config{
-		DBHost:     os.Getenv("DB_HOST"),
-		DBPort:     os.Getenv("DB_PORT"),
-		DBUser:     os.Getenv("DB_USER"),
-		DBPassword: os.Getenv("DB_PASSWORD"),
-		DBName:     os.Getenv("DB_NAME"),
-		RedisHost:  os.Getenv("REDIS_HOST"),
-		RedisPort:  os.Getenv("REDIS_PORT"),
-		APIPort:    os.Getenv("API_PORT"),
+		DBHost:          os.Getenv("DB_HOST"),
+		DBPort:          os.Getenv("DB_PORT"),
+		DBUser:          os.Getenv("DB_USER"),
+		DBPassword:      os.Getenv("DB_PASSWORD"),
+		DBName:          os.Getenv("DB_NAME"),
+		RedisHost:       os.Getenv("REDIS_HOST"),
+		RedisPort:       os.Getenv("REDIS_PORT"),
+		APIPort:         os.Getenv("API_PORT"),
+		JWTSecret:       os.Getenv("JWT_SECRET"),
+		AccessTokenTTL:  accessTTL,
+		RefreshTokenTTL: refreshTTL,
 	}
 
 	return cfg, nil

--- a/backend/internal/handlers/auth_handler.go
+++ b/backend/internal/handlers/auth_handler.go
@@ -1,0 +1,110 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/truyentan/backend/internal/services"
+)
+
+// AuthHandler provides HTTP handlers for authentication endpoints.
+type AuthHandler struct {
+	svc *services.AuthService
+}
+
+// NewAuthHandler creates a new AuthHandler.
+func NewAuthHandler(svc *services.AuthService) *AuthHandler {
+	return &AuthHandler{svc: svc}
+}
+
+// signupRequest represents signup payload.
+type signupRequest struct {
+	Name     string `json:"name" binding:"required"`
+	Email    string `json:"email" binding:"required,email"`
+	Password string `json:"password" binding:"required"`
+}
+
+// signinRequest represents signin payload.
+type signinRequest struct {
+	Email    string `json:"email" binding:"required,email"`
+	Password string `json:"password" binding:"required"`
+}
+
+// refreshRequest represents token refresh payload.
+type refreshRequest struct {
+	RefreshToken string `json:"refresh_token" binding:"required"`
+}
+
+// tokenResponse represents token pair response.
+type tokenResponse services.TokenPair
+
+// Signup godoc
+// @Summary User signup
+// @Description Create new user account
+// @Tags auth
+// @Accept json
+// @Produce json
+// @Param request body signupRequest true "signup request"
+// @Success 201 {object} tokenResponse
+// @Failure 400 {object} gin.H
+// @Router /api/v1/auth/signup [post]
+func (h *AuthHandler) Signup(c *gin.Context) {
+	var req signupRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	tokens, err := h.svc.Signup(req.Name, req.Email, req.Password)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusCreated, tokens)
+}
+
+// Signin godoc
+// @Summary User signin
+// @Tags auth
+// @Accept json
+// @Produce json
+// @Param request body signinRequest true "signin request"
+// @Success 200 {object} tokenResponse
+// @Failure 401 {object} gin.H
+// @Router /api/v1/auth/signin [post]
+func (h *AuthHandler) Signin(c *gin.Context) {
+	var req signinRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	tokens, err := h.svc.Signin(req.Email, req.Password)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, tokens)
+}
+
+// Refresh godoc
+// @Summary Refresh token
+// @Tags auth
+// @Accept json
+// @Produce json
+// @Param request body refreshRequest true "refresh request"
+// @Success 200 {object} tokenResponse
+// @Failure 401 {object} gin.H
+// @Router /api/v1/auth/refresh [post]
+func (h *AuthHandler) Refresh(c *gin.Context) {
+	var req refreshRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	tokens, err := h.svc.Refresh(req.RefreshToken)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, tokens)
+}

--- a/backend/internal/middlewares/auth_jwt.go
+++ b/backend/internal/middlewares/auth_jwt.go
@@ -1,0 +1,36 @@
+package middlewares
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// AuthJWT validates JWT bearer tokens.
+func AuthJWT(secret string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		header := c.GetHeader("Authorization")
+		if header == "" || !strings.HasPrefix(header, "Bearer ") {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "missing token"})
+			return
+		}
+		tokenStr := strings.TrimPrefix(header, "Bearer ")
+		token, err := jwt.Parse(tokenStr, func(t *jwt.Token) (interface{}, error) {
+			if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
+				return nil, errors.New("unexpected signing method")
+			}
+			return []byte(secret), nil
+		})
+		if err != nil || !token.Valid {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid token"})
+			return
+		}
+		if claims, ok := token.Claims.(jwt.MapClaims); ok {
+			c.Set("userID", claims["sub"])
+		}
+		c.Next()
+	}
+}

--- a/backend/internal/services/auth_service.go
+++ b/backend/internal/services/auth_service.go
@@ -1,0 +1,96 @@
+package services
+
+import (
+	"errors"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"golang.org/x/crypto/bcrypt"
+	"gorm.io/gorm"
+
+	"github.com/truyentan/backend/internal/models"
+)
+
+// AuthService handles user authentication and JWT generation.
+type AuthService struct {
+	db         *gorm.DB
+	jwtSecret  string
+	accessTTL  time.Duration
+	refreshTTL time.Duration
+}
+
+// NewAuthService creates a new AuthService.
+func NewAuthService(db *gorm.DB, secret string, accessTTL, refreshTTL time.Duration) *AuthService {
+	return &AuthService{db: db, jwtSecret: secret, accessTTL: accessTTL, refreshTTL: refreshTTL}
+}
+
+// TokenPair represents generated access and refresh tokens.
+type TokenPair struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+}
+
+// Signup creates a new user and returns JWT tokens.
+func (s *AuthService) Signup(name, email, password string) (*TokenPair, error) {
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	if err != nil {
+		return nil, err
+	}
+	user := &models.User{Name: name, Email: email, PasswordHash: string(hash)}
+	if err := s.db.Create(user).Error; err != nil {
+		return nil, err
+	}
+	return s.generateTokens(user.ID)
+}
+
+// Signin authenticates a user and returns JWT tokens.
+func (s *AuthService) Signin(email, password string) (*TokenPair, error) {
+	var user models.User
+	if err := s.db.Where("email = ?", email).First(&user).Error; err != nil {
+		return nil, err
+	}
+	if err := bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(password)); err != nil {
+		return nil, err
+	}
+	return s.generateTokens(user.ID)
+}
+
+// Refresh generates new tokens using a refresh token.
+func (s *AuthService) Refresh(refreshToken string) (*TokenPair, error) {
+	claims := jwt.MapClaims{}
+	token, err := jwt.ParseWithClaims(refreshToken, claims, func(t *jwt.Token) (interface{}, error) {
+		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, errors.New("unexpected signing method")
+		}
+		return []byte(s.jwtSecret), nil
+	})
+	if err != nil || !token.Valid {
+		return nil, err
+	}
+	sub, ok := claims["sub"].(float64)
+	if !ok {
+		return nil, errors.New("invalid token subject")
+	}
+	return s.generateTokens(uint(sub))
+}
+
+func (s *AuthService) generateTokens(userID uint) (*TokenPair, error) {
+	access, err := s.generateToken(userID, s.accessTTL)
+	if err != nil {
+		return nil, err
+	}
+	refresh, err := s.generateToken(userID, s.refreshTTL)
+	if err != nil {
+		return nil, err
+	}
+	return &TokenPair{AccessToken: access, RefreshToken: refresh}, nil
+}
+
+func (s *AuthService) generateToken(userID uint, ttl time.Duration) (string, error) {
+	claims := jwt.MapClaims{
+		"sub": userID,
+		"exp": time.Now().Add(ttl).Unix(),
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	return token.SignedString([]byte(s.jwtSecret))
+}


### PR DESCRIPTION
## Summary
- add config for JWT secrets and token TTLs
- implement auth service, handlers, and JWT middleware
- expose signup, signin, and refresh routes

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68af344221cc833097a30a0b30e688f3