### PR TITLE
feat: add novels API with redis cache

### DIFF
--- a/backend/internal/app/cache/json.go
+++ b/backend/internal/app/cache/json.go
@@ -1,0 +1,27 @@
+package cache
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// GetJSON retrieves a JSON value from Redis and unmarshals it into dest.
+func GetJSON(ctx context.Context, client *redis.Client, key string, dest interface{}) error {
+	data, err := client.Get(ctx, key).Bytes()
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(data, dest)
+}
+
+// SetJSON marshals value to JSON and stores it in Redis with the given TTL.
+func SetJSON(ctx context.Context, client *redis.Client, key string, value interface{}, ttl time.Duration) error {
+	b, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	return client.Set(ctx, key, b, ttl).Err()
+}

--- a/backend/internal/handlers/novel_handler.go
+++ b/backend/internal/handlers/novel_handler.go
@@ -1,0 +1,94 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+
+	"github.com/truyentan/backend/internal/services"
+)
+
+// NovelHandler provides HTTP handlers for novel endpoints.
+type NovelHandler struct {
+	svc *services.NovelService
+}
+
+// NewNovelHandler creates a new NovelHandler.
+func NewNovelHandler(svc *services.NovelService) *NovelHandler {
+	return &NovelHandler{svc: svc}
+}
+
+// ListNovels godoc
+// @Summary List novels
+// @Tags novels
+// @Param page query int false "page number"
+// @Param limit query int false "page size"
+// @Param query query string false "search query"
+// @Param genre query string false "genre filter"
+// @Param status query string false "status filter"
+// @Success 200 {array} services.NovelDetail
+// @Router /api/v1/novels [get]
+func (h *NovelHandler) ListNovels(c *gin.Context) {
+	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
+	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "10"))
+	query := c.Query("query")
+	genre := c.Query("genre")
+	status := c.Query("status")
+	novels, err := h.svc.ListNovels(page, limit, query, genre, status)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, novels)
+}
+
+// GetNovel godoc
+// @Summary Get novel detail
+// @Tags novels
+// @Param id path int true "novel id"
+// @Success 200 {object} services.NovelDetail
+// @Failure 404 {object} gin.H
+// @Router /api/v1/novels/{id} [get]
+func (h *NovelHandler) GetNovel(c *gin.Context) {
+	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+		return
+	}
+	novel, err := h.svc.GetNovel(uint(id))
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, novel)
+}
+
+// ListChapters godoc
+// @Summary List chapters of a novel
+// @Tags novels
+// @Param id path int true "novel id"
+// @Param page query int false "page number"
+// @Param limit query int false "page size"
+// @Success 200 {array} models.Chapter
+// @Router /api/v1/novels/{id}/chapters [get]
+func (h *NovelHandler) ListChapters(c *gin.Context) {
+	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+		return
+	}
+	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
+	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "10"))
+	chapters, err := h.svc.ListChapters(uint(id), page, limit)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, chapters)
+}

--- a/backend/internal/models/novel.go
+++ b/backend/internal/models/novel.go
@@ -8,6 +8,7 @@ type Novel struct {
 	Title       string            `gorm:"type:varchar(255);not null"`
 	Author      string            `gorm:"type:varchar(100);not null"`
 	Description string            `gorm:"type:text"`
+	Status      string            `gorm:"type:varchar(20);not null"`
 	Chapters    []Chapter         `gorm:"constraint:OnDelete:CASCADE"`
 	Genres      []Genre           `gorm:"many2many:novel_genres;constraint:OnDelete:CASCADE"`
 	Favorites   []Favorite        `gorm:"constraint:OnDelete:CASCADE"`

--- a/backend/internal/services/novel_repo.go
+++ b/backend/internal/services/novel_repo.go
@@ -1,0 +1,64 @@
+package services
+
+import (
+	"github.com/truyentan/backend/internal/models"
+	"gorm.io/gorm"
+)
+
+// NovelRepository handles database operations for novels.
+type NovelRepository struct {
+	db *gorm.DB
+}
+
+// NewNovelRepository creates a new NovelRepository.
+func NewNovelRepository(db *gorm.DB) *NovelRepository {
+	return &NovelRepository{db: db}
+}
+
+// ListNovels returns novels filtered by query parameters with pagination.
+func (r *NovelRepository) ListNovels(page, limit int, query, genre, status string) ([]models.Novel, error) {
+	var novels []models.Novel
+	db := r.db.Model(&models.Novel{}).Preload("Genres")
+	if query != "" {
+		db = db.Where("title ILIKE ?", "%"+query+"%")
+	}
+	if status != "" {
+		db = db.Where("status = ?", status)
+	}
+	if genre != "" {
+		db = db.Joins("JOIN novel_genres ng ON ng.novel_id = novels.id").Joins("JOIN genres g ON g.id = ng.genre_id").Where("g.name = ?", genre)
+	}
+	if page > 0 && limit > 0 {
+		db = db.Offset((page - 1) * limit).Limit(limit)
+	}
+	if err := db.Find(&novels).Error; err != nil {
+		return nil, err
+	}
+	return novels, nil
+}
+
+// GetNovel retrieves a novel by ID with genres and chapter count.
+func (r *NovelRepository) GetNovel(id uint) (*models.Novel, int, error) {
+	var novel models.Novel
+	if err := r.db.Preload("Genres").First(&novel, id).Error; err != nil {
+		return nil, 0, err
+	}
+	var count int64
+	if err := r.db.Model(&models.Chapter{}).Where("novel_id = ?", id).Count(&count).Error; err != nil {
+		return &novel, 0, err
+	}
+	return &novel, int(count), nil
+}
+
+// ListChapters returns chapters of a novel with pagination ordered by number.
+func (r *NovelRepository) ListChapters(novelID uint, page, limit int) ([]models.Chapter, error) {
+	var chapters []models.Chapter
+	db := r.db.Where("novel_id = ?", novelID).Order("number")
+	if page > 0 && limit > 0 {
+		db = db.Offset((page - 1) * limit).Limit(limit)
+	}
+	if err := db.Find(&chapters).Error; err != nil {
+		return nil, err
+	}
+	return chapters, nil
+}

--- a/backend/internal/services/novel_service.go
+++ b/backend/internal/services/novel_service.go
@@ -1,0 +1,67 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+
+	"github.com/truyentan/backend/internal/app/cache"
+	"github.com/truyentan/backend/internal/models"
+)
+
+// NovelDetail represents novel details with total chapter count.
+type NovelDetail struct {
+	models.Novel
+	TotalChapters int `json:"total_chapters"`
+}
+
+// NovelService provides novel related operations.
+type NovelService struct {
+	repo  *NovelRepository
+	cache *redis.Client
+}
+
+// NewNovelService creates a new NovelService.
+func NewNovelService(repo *NovelRepository, cache *redis.Client) *NovelService {
+	return &NovelService{repo: repo, cache: cache}
+}
+
+// ListNovels returns novels with optional filters using cache.
+func (s *NovelService) ListNovels(page, limit int, query, genre, status string) ([]models.Novel, error) {
+	ctx := context.Background()
+	key := fmt.Sprintf("novels:%d:%d:%s:%s:%s", page, limit, query, genre, status)
+	var novels []models.Novel
+	if err := cache.GetJSON(ctx, s.cache, key, &novels); err == nil {
+		return novels, nil
+	}
+	novels, err := s.repo.ListNovels(page, limit, query, genre, status)
+	if err != nil {
+		return nil, err
+	}
+	_ = cache.SetJSON(ctx, s.cache, key, novels, 300*time.Second)
+	return novels, nil
+}
+
+// GetNovel returns novel detail with genres and total chapter count using cache.
+func (s *NovelService) GetNovel(id uint) (*NovelDetail, error) {
+	ctx := context.Background()
+	key := fmt.Sprintf("novel:%d", id)
+	var detail NovelDetail
+	if err := cache.GetJSON(ctx, s.cache, key, &detail); err == nil {
+		return &detail, nil
+	}
+	novel, count, err := s.repo.GetNovel(id)
+	if err != nil {
+		return nil, err
+	}
+	detail = NovelDetail{Novel: *novel, TotalChapters: count}
+	_ = cache.SetJSON(ctx, s.cache, key, detail, 300*time.Second)
+	return &detail, nil
+}
+
+// ListChapters returns chapters of a novel with pagination.
+func (s *NovelService) ListChapters(novelID uint, page, limit int) ([]models.Chapter, error) {
+	return s.repo.ListChapters(novelID, page, limit)
+}


### PR DESCRIPTION
## Summary
- add Redis JSON helpers for caching
- implement novel repository, service with 300s cache TTL
- expose novel endpoints for listing, detail, and chapters

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68af3b5fc54883308eaecba547b47236