### PR TITLE
Add core contexts and hooks for auth, UI, and library

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,16 @@
 import AppRouter from './routes';
+import { AuthProvider } from './context/AuthContext';
+import { UIProvider } from './context/UIContext';
+import { LibraryProvider } from './context/LibraryContext';
 
 export default function App() {
-  return <AppRouter />;
+  return (
+    <AuthProvider>
+      <UIProvider>
+        <LibraryProvider>
+          <AppRouter />
+        </LibraryProvider>
+      </UIProvider>
+    </AuthProvider>
+  );
 }

--- a/web/src/context/AuthContext.tsx
+++ b/web/src/context/AuthContext.tsx
@@ -1,0 +1,43 @@
+/* eslint-disable react-refresh/only-export-components */
+import { createContext, useCallback, useMemo, useState, type ReactNode } from 'react';
+
+interface AuthTokens {
+  accessToken: string;
+  refreshToken: string;
+}
+
+interface AuthContextType {
+  user: unknown;
+  tokens: AuthTokens | null;
+  signIn: (user: unknown, tokens: AuthTokens) => void;
+  signOut: () => void;
+  refresh: (tokens: AuthTokens) => void;
+}
+
+export const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<unknown>(null);
+  const [tokens, setTokens] = useState<AuthTokens | null>(null);
+
+  const signIn = useCallback((nextUser: unknown, nextTokens: AuthTokens) => {
+    setUser(nextUser);
+    setTokens(nextTokens);
+  }, []);
+
+  const signOut = useCallback(() => {
+    setUser(null);
+    setTokens(null);
+  }, []);
+
+  const refresh = useCallback((nextTokens: AuthTokens) => {
+    setTokens(nextTokens);
+  }, []);
+
+  const value = useMemo(
+    () => ({ user, tokens, signIn, signOut, refresh }),
+    [user, tokens, signIn, signOut, refresh],
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}

--- a/web/src/context/LibraryContext.tsx
+++ b/web/src/context/LibraryContext.tsx
@@ -1,0 +1,31 @@
+/* eslint-disable react-refresh/only-export-components */
+import { createContext, useMemo, useReducer, type ReactNode } from 'react';
+import {
+  libraryReducer,
+  initialLibraryState,
+  type LibraryAction,
+  type LibraryState,
+} from '../reducers/libraryReducer';
+
+interface LibraryContextType extends LibraryState {
+  dispatch: React.Dispatch<LibraryAction>;
+  filteredNovels: Array<{ id: string; title: string }>;
+}
+
+export const LibraryContext = createContext<LibraryContextType | undefined>(undefined);
+
+export function LibraryProvider({ children }: { children: ReactNode }) {
+  const [state, dispatch] = useReducer(libraryReducer, initialLibraryState);
+
+  const filteredNovels = useMemo(() => {
+    const query = state.filters.query.toLowerCase();
+    return state.novels.filter((n) => n.title.toLowerCase().includes(query));
+  }, [state.novels, state.filters]);
+
+  const value = useMemo(
+    () => ({ ...state, dispatch, filteredNovels }),
+    [state, dispatch, filteredNovels],
+  );
+
+  return <LibraryContext.Provider value={value}>{children}</LibraryContext.Provider>;
+}

--- a/web/src/context/UIContext.tsx
+++ b/web/src/context/UIContext.tsx
@@ -1,0 +1,43 @@
+/* eslint-disable react-refresh/only-export-components */
+import { createContext, useCallback, useMemo, useState, type ReactNode } from 'react';
+
+interface UIContextType {
+  modals: Record<string, boolean>;
+  theme: 'light' | 'dark';
+  fontSize: number;
+  openModal: (name: string) => void;
+  closeModal: (name: string) => void;
+  toggleTheme: () => void;
+  setFontSize: (size: number) => void;
+}
+
+export const UIContext = createContext<UIContextType | undefined>(undefined);
+
+export function UIProvider({ children }: { children: ReactNode }) {
+  const [modals, setModals] = useState<Record<string, boolean>>({});
+  const [theme, setTheme] = useState<'light' | 'dark'>('light');
+  const [fontSize, setFontSizeState] = useState<number>(16);
+
+  const openModal = useCallback((name: string) => {
+    setModals((m) => ({ ...m, [name]: true }));
+  }, []);
+
+  const closeModal = useCallback((name: string) => {
+    setModals((m) => ({ ...m, [name]: false }));
+  }, []);
+
+  const toggleTheme = useCallback(() => {
+    setTheme((t) => (t === 'light' ? 'dark' : 'light'));
+  }, []);
+
+  const setFontSize = useCallback((size: number) => {
+    setFontSizeState(size);
+  }, []);
+
+  const value = useMemo(
+    () => ({ modals, theme, fontSize, openModal, closeModal, toggleTheme, setFontSize }),
+    [modals, theme, fontSize, openModal, closeModal, toggleTheme, setFontSize],
+  );
+
+  return <UIContext.Provider value={value}>{children}</UIContext.Provider>;
+}

--- a/web/src/hooks/useAuth.ts
+++ b/web/src/hooks/useAuth.ts
@@ -1,0 +1,10 @@
+import { useContext } from 'react';
+import { AuthContext } from '../context/AuthContext';
+
+export default function useAuth() {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+}

--- a/web/src/hooks/useModal.ts
+++ b/web/src/hooks/useModal.ts
@@ -1,0 +1,16 @@
+import { useContext } from 'react';
+import { UIContext } from '../context/UIContext';
+
+export default function useModal(name: string) {
+  const context = useContext(UIContext);
+  if (!context) {
+    throw new Error('useModal must be used within a UIProvider');
+  }
+  const { modals, openModal, closeModal } = context;
+  const isOpen = !!modals[name];
+  return {
+    isOpen,
+    open: () => openModal(name),
+    close: () => closeModal(name),
+  };
+}

--- a/web/src/reducers/libraryReducer.ts
+++ b/web/src/reducers/libraryReducer.ts
@@ -1,0 +1,34 @@
+export interface LibraryState {
+  novels: Array<{ id: string; title: string }>;
+  filters: { query: string };
+  page: number;
+  pageSize: number;
+}
+
+export type LibraryAction =
+  | { type: 'SET_NOVELS'; payload: Array<{ id: string; title: string }> }
+  | { type: 'SET_FILTERS'; payload: { query: string } }
+  | { type: 'SET_PAGE'; payload: number }
+  | { type: 'SET_PAGE_SIZE'; payload: number };
+
+export const initialLibraryState: LibraryState = {
+  novels: [],
+  filters: { query: '' },
+  page: 1,
+  pageSize: 10,
+};
+
+export function libraryReducer(state: LibraryState, action: LibraryAction): LibraryState {
+  switch (action.type) {
+    case 'SET_NOVELS':
+      return { ...state, novels: action.payload };
+    case 'SET_FILTERS':
+      return { ...state, filters: action.payload, page: 1 };
+    case 'SET_PAGE':
+      return { ...state, page: action.payload };
+    case 'SET_PAGE_SIZE':
+      return { ...state, pageSize: action.payload, page: 1 };
+    default:
+      return state;
+  }
+}


### PR DESCRIPTION
## Summary
- create AuthContext with signIn/signOut/refresh helpers
- add UIContext for modals, theme toggling, and font sizing
- implement LibraryContext with reducer-based state and filtering
- expose useAuth and useModal hooks and wrap app with new providers

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af443f300c8330b81a7b18479fbcc2