### PR TITLE
feat(auth): add sign-in and sign-up forms

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,9 +8,12 @@
       "name": "web",
       "version": "0.0.0",
       "dependencies": {
+        "@hookform/resolvers": "^5.2.1",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
-        "react-router-dom": "^7.8.2"
+        "react-hook-form": "^7.62.0",
+        "react-router-dom": "^7.8.2",
+        "yup": "^1.7.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.33.0",
@@ -937,6 +940,18 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.2.1.tgz",
+      "integrity": "sha512-u0+6X58gkjMcxur1wRWokA7XsiiBJ6aK17aPZxhkoYiK5J+HcTx0Vhu9ovXe6H+dVpO6cjrn2FkJTryXEMlryQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1408,6 +1423,12 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -3609,6 +3630,12 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/property-expr": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.6.tgz",
+      "integrity": "sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA==",
+      "license": "MIT"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3659,6 +3686,22 @@
       },
       "peerDependencies": {
         "react": "^19.1.1"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.62.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.62.0.tgz",
+      "integrity": "sha512-7KWFejc98xqG/F4bAxpL41NB3o1nnvQO1RWZT3TqRZYL8RryQETGfEdVnJN2fy1crCiBLLjkRBVK05j24FxJGA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-refresh": {
@@ -4149,6 +4192,12 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tiny-case": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-case/-/tiny-case-1.0.3.tgz",
+      "integrity": "sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.14",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
@@ -4210,6 +4259,12 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toposort": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
+      "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==",
+      "license": "MIT"
+    },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
@@ -4241,6 +4296,18 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/typescript": {
@@ -4587,6 +4654,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yup": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-1.7.0.tgz",
+      "integrity": "sha512-VJce62dBd+JQvoc+fCVq+KZfPHr+hXaxCcVgotfwWvlR0Ja3ffYKaJBT8rptPOSKOGJDCUnW2C2JWpud7aRP6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "property-expr": "^2.0.5",
+        "tiny-case": "^1.0.3",
+        "toposort": "^2.0.2",
+        "type-fest": "^2.19.0"
       }
     }
   }

--- a/web/package.json
+++ b/web/package.json
@@ -11,9 +11,12 @@
     "format": "prettier --write ."
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.2.1",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
-    "react-router-dom": "^7.8.2"
+    "react-hook-form": "^7.62.0",
+    "react-router-dom": "^7.8.2",
+    "yup": "^1.7.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/web/src/forms/providers/FormProvider.tsx
+++ b/web/src/forms/providers/FormProvider.tsx
@@ -1,0 +1,25 @@
+import {
+  FormProvider as RHFormProvider,
+  UseFormReturn,
+  FieldValues,
+  SubmitHandler,
+} from 'react-hook-form';
+import { ReactNode } from 'react';
+
+interface Props<T extends FieldValues> {
+  methods: UseFormReturn<T>;
+  onSubmit: SubmitHandler<T>;
+  children: ReactNode;
+}
+
+export default function FormProvider<T extends FieldValues>({
+  methods,
+  onSubmit,
+  children,
+}: Props<T>) {
+  return (
+    <RHFormProvider {...methods}>
+      <form onSubmit={methods.handleSubmit(onSubmit)}>{children}</form>
+    </RHFormProvider>
+  );
+}

--- a/web/src/forms/validators/auth.ts
+++ b/web/src/forms/validators/auth.ts
@@ -1,0 +1,15 @@
+import * as yup from 'yup';
+
+export const signInSchema = yup.object({
+  email: yup.string().email('Invalid email').required('Email is required'),
+  password: yup.string().required('Password is required'),
+});
+
+export const signUpSchema = yup.object({
+  name: yup.string().required('Name is required'),
+  email: yup.string().email('Invalid email').required('Email is required'),
+  password: yup.string().required('Password is required'),
+});
+
+export type SignInFormValues = yup.InferType<typeof signInSchema>;
+export type SignUpFormValues = yup.InferType<typeof signUpSchema>;

--- a/web/src/pages/Auth/SignIn.tsx
+++ b/web/src/pages/Auth/SignIn.tsx
@@ -1,0 +1,64 @@
+import { useForm } from 'react-hook-form';
+import { yupResolver } from '@hookform/resolvers/yup';
+import { Link, useNavigate } from 'react-router-dom';
+import { useContext } from 'react';
+import { signInSchema, type SignInFormValues } from '../../forms/validators/auth';
+import FormProvider from '../../forms/providers/FormProvider';
+import { AuthContext } from '../../context/AuthContext';
+import { post } from '../../services/api';
+
+export default function SignIn() {
+  const methods = useForm<SignInFormValues>({
+    resolver: yupResolver(signInSchema),
+    defaultValues: { email: '', password: '' },
+  });
+
+  const auth = useContext(AuthContext);
+  const navigate = useNavigate();
+
+  const onSubmit = async (data: SignInFormValues) => {
+    try {
+      const tokens = await post<{ access_token: string; refresh_token: string }>(
+        '/auth/signin',
+        data,
+      );
+      const authTokens = {
+        accessToken: tokens.access_token,
+        refreshToken: tokens.refresh_token,
+      };
+      localStorage.setItem('accessToken', authTokens.accessToken);
+      localStorage.setItem('refreshToken', authTokens.refreshToken);
+      auth?.signIn(null, authTokens);
+      navigate('/');
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const {
+    register,
+    formState: { errors },
+  } = methods;
+
+  return (
+    <FormProvider methods={methods} onSubmit={onSubmit}>
+      <div>
+        <h1>Sign In</h1>
+        <div>
+          <label htmlFor="email">Email</label>
+          <input id="email" type="email" {...register('email')} />
+          {errors.email && <p>{errors.email.message}</p>}
+        </div>
+        <div>
+          <label htmlFor="password">Password</label>
+          <input id="password" type="password" {...register('password')} />
+          {errors.password && <p>{errors.password.message}</p>}
+        </div>
+        <button type="submit">Sign In</button>
+        <p>
+          Don't have an account? <Link to="/signup">Sign Up</Link>
+        </p>
+      </div>
+    </FormProvider>
+  );
+}

--- a/web/src/pages/Auth/SignUp.tsx
+++ b/web/src/pages/Auth/SignUp.tsx
@@ -1,0 +1,69 @@
+import { useForm } from 'react-hook-form';
+import { yupResolver } from '@hookform/resolvers/yup';
+import { Link, useNavigate } from 'react-router-dom';
+import { useContext } from 'react';
+import { signUpSchema, type SignUpFormValues } from '../../forms/validators/auth';
+import FormProvider from '../../forms/providers/FormProvider';
+import { AuthContext } from '../../context/AuthContext';
+import { post } from '../../services/api';
+
+export default function SignUp() {
+  const methods = useForm<SignUpFormValues>({
+    resolver: yupResolver(signUpSchema),
+    defaultValues: { name: '', email: '', password: '' },
+  });
+
+  const auth = useContext(AuthContext);
+  const navigate = useNavigate();
+
+  const onSubmit = async (data: SignUpFormValues) => {
+    try {
+      const tokens = await post<{ access_token: string; refresh_token: string }>(
+        '/auth/signup',
+        data,
+      );
+      const authTokens = {
+        accessToken: tokens.access_token,
+        refreshToken: tokens.refresh_token,
+      };
+      localStorage.setItem('accessToken', authTokens.accessToken);
+      localStorage.setItem('refreshToken', authTokens.refreshToken);
+      auth?.signIn(null, authTokens);
+      navigate('/');
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const {
+    register,
+    formState: { errors },
+  } = methods;
+
+  return (
+    <FormProvider methods={methods} onSubmit={onSubmit}>
+      <div>
+        <h1>Sign Up</h1>
+        <div>
+          <label htmlFor="name">Name</label>
+          <input id="name" type="text" {...register('name')} />
+          {errors.name && <p>{errors.name.message}</p>}
+        </div>
+        <div>
+          <label htmlFor="email">Email</label>
+          <input id="email" type="email" {...register('email')} />
+          {errors.email && <p>{errors.email.message}</p>}
+        </div>
+        <div>
+          <label htmlFor="password">Password</label>
+          <input id="password" type="password" {...register('password')} />
+          {errors.password && <p>{errors.password.message}</p>}
+        </div>
+        <button type="submit">Sign Up</button>
+        <p>
+          Already have an account? <Link to="/signin">Sign In</Link>
+        </p>
+      </div>
+    </FormProvider>
+  );
+}

--- a/web/src/routes/index.tsx
+++ b/web/src/routes/index.tsx
@@ -1,11 +1,15 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import Home from '../pages/Home';
+import SignIn from '../pages/Auth/SignIn';
+import SignUp from '../pages/Auth/SignUp';
 
 export default function AppRouter() {
   return (
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<Home />} />
+        <Route path="/signin" element={<SignIn />} />
+        <Route path="/signup" element={<SignUp />} />
       </Routes>
     </BrowserRouter>
   );


### PR DESCRIPTION
## Summary
- add authentication validators
- introduce form provider wrapper
- implement sign-in and sign-up pages with RHF & Yup
- register auth routes

## Testing
- `npm test` (fails: Missing script: "test")
- `npx eslint src/forms/providers/FormProvider.tsx src/forms/validators/auth.ts src/pages/Auth/SignIn.tsx src/pages/Auth/SignUp.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68af45ec60c88330ad89f68c793f1d06