### PR TITLE
feat: add novel detail page with chapter list

### DIFF
--- a/web/src/components/novels/ChapterList.tsx
+++ b/web/src/components/novels/ChapterList.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { get } from '../../services/api';
+
+interface Chapter {
+  id: string;
+  title: string;
+  number: number;
+}
+
+interface ChapterListResponse {
+  chapters: Chapter[];
+  total: number;
+}
+
+export default function ChapterList({ novelId }: { novelId: string }) {
+  const [chapters, setChapters] = useState<Chapter[]>([]);
+  const [page, setPage] = useState(1);
+  const [pageSize] = useState(10);
+  const [total, setTotal] = useState(0);
+
+  useEffect(() => {
+    async function fetchChapters() {
+      try {
+        const data = await get<ChapterListResponse>(`/novels/${novelId}/chapters`, {
+          params: { page, limit: pageSize },
+        });
+        setChapters(data.chapters);
+        setTotal(data.total);
+      } catch {
+        setChapters([]);
+        setTotal(0);
+      }
+    }
+    fetchChapters();
+  }, [novelId, page, pageSize]);
+
+  const progress = localStorage.getItem(`readingProgress-${novelId}`);
+
+  return (
+    <div>
+      {progress && (
+        <div className="mb-4">
+          <Link to={`/novels/${novelId}/chapters/${progress}`} className="text-blue-500 underline">
+            Đọc tiếp tục
+          </Link>
+        </div>
+      )}
+      <ul>
+        {chapters.map((chapter) => (
+          <li key={chapter.id} className="py-1">
+            <Link
+              to={`/novels/${novelId}/chapters/${chapter.id}`}
+              className="text-blue-500 hover:underline"
+            >
+              {chapter.number}. {chapter.title}
+            </Link>
+          </li>
+        ))}
+      </ul>
+      <div className="flex gap-2 mt-4">
+        <button
+          type="button"
+          disabled={page === 1}
+          onClick={() => setPage((p) => Math.max(1, p - 1))}
+          className="px-2 py-1 border rounded disabled:opacity-50"
+        >
+          Prev
+        </button>
+        <button
+          type="button"
+          disabled={page * pageSize >= total}
+          onClick={() => setPage((p) => p + 1)}
+          className="px-2 py-1 border rounded disabled:opacity-50"
+        >
+          Next
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/Novels/NovelDetail.tsx
+++ b/web/src/pages/Novels/NovelDetail.tsx
@@ -1,0 +1,46 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { get } from '../../services/api';
+import ChapterList from '../../components/novels/ChapterList';
+
+interface Novel {
+  id: string;
+  title: string;
+  author: string;
+  description: string;
+  genres: string[];
+  rating: number;
+}
+
+export default function NovelDetail() {
+  const { id } = useParams<{ id: string }>();
+  const [novel, setNovel] = useState<Novel | null>(null);
+
+  useEffect(() => {
+    async function fetchNovel() {
+      if (!id) return;
+      try {
+        const data = await get<Novel>(`/novels/${id}`);
+        setNovel(data);
+      } catch {
+        setNovel(null);
+      }
+    }
+    fetchNovel();
+  }, [id]);
+
+  if (!novel) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-2">{novel.title}</h1>
+      <p className="mb-2">Tác giả: {novel.author}</p>
+      <p className="mb-4">{novel.description}</p>
+      <p className="mb-2">Thể loại: {novel.genres.join(', ')}</p>
+      <p className="mb-4">Đánh giá: {novel.rating}</p>
+      <ChapterList novelId={novel.id} />
+    </div>
+  );
+}

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosError, AxiosRequestConfig, AxiosResponse } from "axios";
+import axios, { AxiosError, AxiosRequestConfig, AxiosResponse } from 'axios';
 
 const api = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL as string,
@@ -7,7 +7,7 @@ const api = axios.create({
 let isRefreshing = false;
 let failedQueue: {
   resolve: (value?: unknown) => void;
-  reject: (reason?: any) => void;
+  reject: (reason?: unknown) => void;
 }[] = [];
 
 const processQueue = (error: unknown, token: string | null = null) => {
@@ -22,7 +22,7 @@ const processQueue = (error: unknown, token: string | null = null) => {
 };
 
 api.interceptors.request.use((config) => {
-  const token = localStorage.getItem("accessToken");
+  const token = localStorage.getItem('accessToken');
   if (token) {
     config.headers = config.headers || {};
     config.headers.Authorization = `Bearer ${token}`;
@@ -55,13 +55,13 @@ api.interceptors.response.use(
       isRefreshing = true;
 
       try {
-        const refreshToken = localStorage.getItem("refreshToken");
+        const refreshToken = localStorage.getItem('refreshToken');
         const { data } = await axios.post(
           `${import.meta.env.VITE_API_BASE_URL as string}/auth/refresh`,
           { refreshToken },
         );
-        const accessToken = (data as any).accessToken;
-        localStorage.setItem("accessToken", accessToken);
+        const accessToken = (data as { accessToken: string }).accessToken;
+        localStorage.setItem('accessToken', accessToken);
         processQueue(null, accessToken);
         if (originalRequest.headers) {
           originalRequest.headers.Authorization = `Bearer ${accessToken}`;
@@ -79,10 +79,7 @@ api.interceptors.response.use(
   },
 );
 
-export const get = async <T = unknown>(
-  url: string,
-  config?: AxiosRequestConfig,
-): Promise<T> => {
+export const get = async <T = unknown>(url: string, config?: AxiosRequestConfig): Promise<T> => {
   try {
     const { data } = await api.get<T>(url, config);
     return data;


### PR DESCRIPTION
## Summary
- add novel detail page to show story info
- implement chapter list component with pagination and resume reading
- normalize api service typing and formatting

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af461df09483308d0f4c0b2bbff166